### PR TITLE
Shorter loss

### DIFF
--- a/yogo/yogo_loss.py
+++ b/yogo/yogo_loss.py
@@ -129,11 +129,8 @@ class YOGOLoss(torch.nn.modules.loss._Loss):
         # See "Appendix A" in the YOGO paper.
         objectness_loss = (
             self.mse(pred_batch[:, 4, :, :], label_batch[:, 0, :, :])
-            * (
-                label_batch[:, 0, :, :] * (1 - self.no_obj_weight) + self.no_obj_weight
-            ).sum()
-            / batch_size
-        )
+            * (label_batch[:, 0, :, :] * (1 - self.no_obj_weight) + self.no_obj_weight)
+        ).sum() / batch_size
 
         loss = objectness_loss + iou_loss + classification_loss
 


### PR DESCRIPTION
Realized that we can simplify our loss function so we have 3 or 4 fewer tensor operations, which is nice :)

https://github.com/czbiohub-sf/yogo-paper/blob/40080755ac9c10c303b1f96d1634ce9f2a887a1b/paper.pdf

went from this

<img width="440" alt="Screenshot 2024-03-07 at 13 58 50" src="https://github.com/czbiohub-sf/yogo/assets/20530172/36ed11f8-eb04-4369-8a75-d53edf5390c6">
to this

<img width="362" alt="Screenshot 2024-03-07 at 13 59 09" src="https://github.com/czbiohub-sf/yogo/assets/20530172/c39d73c2-430b-49a7-bc2d-49145eb8c91c">
