### PR TITLE
Improve CLI startup time by making yogo cli imports lazy

### DIFF
--- a/yogo/__main__.py
+++ b/yogo/__main__.py
@@ -1,18 +1,7 @@
 import sys
 import torch
 
-from yogo.infer import do_infer
-from yogo.train import do_training
-from yogo.utils.test_model import do_model_test
 from yogo.utils.argparsers import global_parser
-
-no_onnx = False
-onnx_err = ""
-try:
-    from yogo.utils.export_model import do_export
-except ImportError as e:
-    no_onnx = True
-    onnx_err = str(e)
 
 
 def main():
@@ -20,16 +9,31 @@ def main():
     args = p.parse_args()
 
     if args.task == "train":
+        from yogo.train import do_training
+
         do_training(args)
     elif args.task == "test":
+        from yogo.utils.test_model import do_model_test
+
         do_model_test(args)
     elif args.task == "export":
+        no_onnx = False
+        onnx_err = ""
+        try:
+            from yogo.utils.export_model import do_export
+        except ImportError as e:
+            no_onnx = True
+            onnx_err = str(e)
+
         if no_onnx:
             print("onnx is not installed; install yogo with `pip3 install .[onnx]`")
             print(f"recieved error {onnx_err}")
             sys.exit(1)
+
         do_export(args)
     elif args.task == "infer":
+        from yogo.infer import do_infer
+
         do_infer(args)
     else:
         p.print_help()

--- a/yogo/utils/argparsers.py
+++ b/yogo/utils/argparsers.py
@@ -3,10 +3,7 @@ import argparse
 
 from pathlib import Path
 
-from yogo.model_defns import MODELS
 from yogo.data.split_fractions import SplitFractions
-from yogo.utils.default_hyperparams import DefaultHyperparams as df
-
 
 try:
     boolean_action = argparse.BooleanOptionalAction  # type: ignore
@@ -99,6 +96,10 @@ def global_parser():
 
 
 def train_parser(parser=None):
+    # lazy-import
+    from yogo.model_defns import MODELS
+    from yogo.utils.default_hyperparams import DefaultHyperparams as df
+
     if parser is None:
         parser = argparse.ArgumentParser(
             description="commence a training run", allow_abbrev=False


### PR DESCRIPTION
So far, we touch on improving #143 but we need more work. First shot!

```console
$ cat ./test_cli_startup_time.sh  # testing script for measuring cli startup performance
#!/usr/bin/env bash

hyperfine "yogo infer --help"
hyperfine "yogo train --help"
hyperfine "yogo test --help"
hyperfine "yogo export --help"

$  git rev-parse HEAD  # let's get a baseline on main
b3aa993a4bbfaf7322ad73c6bef31523613034d2

$ ./test_cli_startup_time.sh
Benchmark 1: yogo infer --help
  Time (mean ± σ):      3.011 s ±  0.031 s    [User: 3.487 s, System: 0.839 s]
  Range (min … max):    2.963 s …  3.060 s    10 runs

Benchmark 1: yogo train --help
  Time (mean ± σ):      2.969 s ±  0.037 s    [User: 3.309 s, System: 1.018 s]
  Range (min … max):    2.933 s …  3.055 s    10 runs

Benchmark 1: yogo test --help
  Time (mean ± σ):      2.920 s ±  0.033 s    [User: 3.171 s, System: 1.139 s]
  Range (min … max):    2.882 s …  2.975 s    10 runs

Benchmark 1: yogo export --help
  Time (mean ± σ):      2.983 s ±  0.046 s    [User: 3.393 s, System: 0.934 s]
  Range (min … max):    2.933 s …  3.081 s    10 runs

$ git rev-parse HEAD  # on this branch, started by making imports lazy - ie only import the packages that the cli needs for execution
99987a0e7c678c9121d307a8e8fd0533fea691f7

$ ./test_cli_startup_time.sh
Benchmark 1: yogo infer --help
  Time (mean ± σ):      2.125 s ±  0.076 s    [User: 2.763 s, System: 0.720 s]
  Range (min … max):    2.027 s …  2.280 s    10 runs

Benchmark 1: yogo train --help
  Time (mean ± σ):      2.102 s ±  0.054 s    [User: 2.671 s, System: 0.803 s]
  Range (min … max):    2.011 s …  2.191 s    10 runs

Benchmark 1: yogo test --help
  Time (mean ± σ):      2.046 s ±  0.087 s    [User: 2.657 s, System: 0.823 s]
  Range (min … max):    1.977 s …  2.284 s    10 runs

Benchmark 1: yogo export --help
  Time (mean ± σ):      2.032 s ±  0.036 s    [User: 2.523 s, System: 0.929 s]
  Range (min … max):    1.967 s …  2.091 s    10 runs
```

So far, just making imports lazy in `__main__.py` is a 33% improvement, shaving roughly a second.

Can we get lazier?