### PR TITLE
Update argparsers.py

### DIFF
--- a/yogo/utils/argparsers.py
+++ b/yogo/utils/argparsers.py
@@ -269,7 +269,7 @@ def test_parser(parser=None):
     parser.add_argument(
         "--wandb",
         action=argparse.BooleanOptionalAction,
-        default=False,
+        default=True,
         help=(
             "log to wandb - this will create a new run. If neither this nor "
             "--wandb-resume-id are provided, the run will be saved to a new folder"


### PR DESCRIPTION
- Make default True because no wandb is not ready for use. `yogo train` still calls `wandb.init()` by default anyway. Setting to False will result in errors for now. This sort of patches one of the issues raised in #153 , so at least you don't require a --wandb argument to prevent the test from failing