### PR TITLE
Fix `normalize_images` to yogo from config

### DIFF
--- a/yogo/model.py
+++ b/yogo/model.py
@@ -143,7 +143,6 @@ class YOGO(nn.Module):
         return model, {
             "step": global_step,
             "class_names": class_names,
-            "normalize_images": params["normalize_images"],
         }
 
     def to(self, device, *args, **kwargs):

--- a/yogo/utils/test_model.py
+++ b/yogo/utils/test_model.py
@@ -68,7 +68,7 @@ def test_model(args: argparse.Namespace) -> None:
         64,
         y.get_grid_size()[0],
         y.get_grid_size()[1],
-        normalize_images=cfg["normalize_images"],
+        normalize_images=y.normalize_images,
     )
 
     test_dataset: Dataset[ObjectDetectionDataset] = dataloaders["test"].dataset


### PR DESCRIPTION
I regret my decision to include `config` in `from_pth` - ideally all of this information would be in the YOGO model. It would make things much simpler